### PR TITLE
feat(ci): add codecov

### DIFF
--- a/.github/workflows/codecov.yml
+++ b/.github/workflows/codecov.yml
@@ -1,0 +1,35 @@
+name: Code coverage
+concurrency:
+  group: "${{ github.workflow }}-${{ github.ref }}"
+  cancel-in-progress: "${{ github.ref != 'refs/heads/main' }}"
+"on":
+  workflow_dispatch:
+  merge_group:
+  pull_request:
+    branches:
+      - main
+  push:
+    branches:
+      - main
+
+jobs:
+  codedov:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: taiki-e/install-action@cargo-llvm-cov
+      - run: cargo llvm-cov --all-features --lcov --output-path lcov.info
+        env:
+          RUSTC_WRAPPER:
+      - uses: actions/upload-artifact@v4
+        with:
+          name: lcov.info
+          path: lcov.info
+          if-no-files-found: error
+      - name: Upload to codecov
+        env:
+          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
+        run: |
+          curl -Os https://uploader.codecov.io/latest/linux/codecov
+          chmod +x codecov
+          ./codecov -f lcov.info -Z

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Filecoin Common Node API Specification
 
+[![codecov](https://codecov.io/gh/ChainSafe/filecoin-common-node-api/graph/badge.svg?token=15C2O7Z4G6)](https://codecov.io/gh/ChainSafe/filecoin-common-node-api)
+
 This repo is an appendix to the [Filecoin Common Node API FIP](https://github.com/filecoin-project/FIPs/pull/1027).
 
 # Spec


### PR DESCRIPTION
- Added code coverage check and badge
- at the moment we stand on whooping 17% code coverage, which is putting **a lot** of faith in the compiler :crab: https://app.codecov.io/gh/ChainSafe/filecoin-common-node-api/tree/add-codecov